### PR TITLE
Update userId to match the one we use in the guide

### DIFF
--- a/app/Chatkit Quickstart/Chatkit.plist
+++ b/app/Chatkit Quickstart/Chatkit.plist
@@ -16,6 +16,6 @@
         <key>ChatkitRoomId</key>
         <string>alice_and_bob</string>
         <key>ChatkitUserId</key>
-        <string>alice</string>
+        <string>pusher-quick-start-alice</string>
     </dict>
 </plist>


### PR DESCRIPTION
We needed something a bit more unique and explicitly related to the guide